### PR TITLE
[FIX] KBT-252

### DIFF
--- a/addons/kbt_good_receipt_api/controllers/main.py
+++ b/addons/kbt_good_receipt_api/controllers/main.py
@@ -116,13 +116,15 @@ class ReceiptController(KBTApiBase):
                 raise ValueError(
                     "Date %s is back date of order date/accounting date." %
                     x_bill_date)
+        else:
+            x_bill_date = datetime.today()
 
-            vals.update({
-                'x_bill_date': x_bill_date,
-            })
-            inv_vals.update({
-                'invoice_date': x_bill_date,
-            })
+        vals.update({
+            'x_bill_date': x_bill_date,
+        })
+        inv_vals.update({
+            'invoice_date': x_bill_date,
+        })
 
         stock_id.write(vals)
         res = stock_id._pre_action_done_hook()

--- a/addons/kbt_purchase_api/controllers/main.py
+++ b/addons/kbt_purchase_api/controllers/main.py
@@ -203,22 +203,25 @@ class PurchaseController(KBTApiBase):
         if params.get('x_bill_date'):
             x_bill_date = datetime.strptime(
                 params.get('x_bill_date'), '%d-%m-%Y')
-            acc_vals.update({
-                'invoice_date': x_bill_date
-            })
 
-        old_only_date = str(purchase_ref_id.date_order).split(' ')
-        temp_date = old_only_date[0].split('-')
-        new_only_date = '{0}-{1}-{2}'.format(
-            temp_date[2], temp_date[1], temp_date[0])
-        purchase_only_date = datetime.strptime(
-            new_only_date, '%d-%m-%Y'
-        )
+            old_only_date = str(purchase_ref_id.date_order).split(' ')
+            temp_date = old_only_date[0].split('-')
+            new_only_date = '{0}-{1}-{2}'.format(
+                temp_date[2], temp_date[1], temp_date[0])
+            purchase_only_date = datetime.strptime(
+                new_only_date, '%d-%m-%Y'
+            )
 
-        if purchase_only_date > x_bill_date:
-            raise ValueError(
-                "Date %s is back date of order date/accounting date." %
-                x_bill_date)
+            if purchase_only_date > x_bill_date:
+                raise ValueError(
+                    "Date %s is back date of order date/accounting date." %
+                    x_bill_date)
+        else:
+            x_bill_date = datetime.today()
+
+        acc_vals.update({
+            'invoice_date': x_bill_date
+        })
 
         purchase_ref_id.write({
             'order_line': update_line_lst


### PR DESCRIPTION
GoodReceiptApi, PurchaseApi: if api have no 'date', add today date instead